### PR TITLE
Add GitHub token as an input in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
     description: "Should it push image to docker"
     required: false
     default: true
+  github-token:
+    description: "GitHub token"
+    required: false
 
 runs:
   using: "composite"
@@ -53,7 +56,7 @@ runs:
     - name: Build and Push Docker Image
       uses: docker/build-push-action@v5
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
         DOCKER_BUILDKIT: 1
       with:
         context: .


### PR DESCRIPTION
This pull request adds a new input, `github-token`, to the `action.yml` file. This input allows users to provide their GitHub token when running the action. This change improves the flexibility and security of the action by allowing users to use their own tokens instead of relying on the default `GITHUB_TOKEN`.