### PR TITLE
Update GitHub token to GitHub Personal Access Token in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,8 @@ inputs:
     description: "Should it push image to docker"
     required: false
     default: true
-  github-token:
-    description: "GitHub token"
+  github-pat:
+    description: "GitHub Personal Access Token"
     required: false
 
 runs:
@@ -56,8 +56,9 @@ runs:
     - name: Build and Push Docker Image
       uses: docker/build-push-action@v5
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
         DOCKER_BUILDKIT: 1
+      build-args: |
+        GITHUB_PAT=${{ inputs.github-pat }}
       with:
         context: .
         file: ./Dockerfile


### PR DESCRIPTION
This pull request updates the `github-token` input in the `action.yml` file to `github-pat` to reflect the use of a GitHub Personal Access Token instead of a regular token. This change ensures better security and aligns with best practices for authentication.