### PR TITLE
Update action.yml to include GITHUB_PAT as a secret

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,8 +57,6 @@ runs:
       uses: docker/build-push-action@v5
       env:
         DOCKER_BUILDKIT: 1
-      build-args: |
-        GITHUB_PAT=${{ inputs.github-pat }}
       with:
         context: .
         file: ./Dockerfile
@@ -67,3 +65,5 @@ runs:
         cache-from: type=registry,ref=${{ inputs.docker-username }}/${{ inputs.repo }}:buildcache
         cache-to: type=registry,ref=${{ inputs.docker-username }}/${{ inputs.repo }}:buildcache,mode=max
         builder: ${{ steps.setup-buildx.outputs.name }}
+        secrets: |
+          GITHUB_PAT=${{ inputs.github-pat }}

--- a/action.yml
+++ b/action.yml
@@ -66,4 +66,4 @@ runs:
         cache-to: type=registry,ref=${{ inputs.docker-username }}/${{ inputs.repo }}:buildcache,mode=max
         builder: ${{ steps.setup-buildx.outputs.name }}
         secrets: |
-          GITHUB_PAT=${{ inputs.github-pat }}
+          github_pat=${{ inputs.github-pat }}


### PR DESCRIPTION
This pull request updates the action.yml file to include GITHUB_PAT as a secret. This change ensures that the GitHub Personal Access Token is securely stored and not exposed in the repository.