### PR TITLE
Change github-pat to github-token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,5 +73,5 @@ runs:
         builder: ${{ steps.setup-buildx.outputs.name }}
         secrets: |
           github_username=${{ inputs.github-username }}
-          github_pat=${{ inputs.github-pat }}
+          github_token=${{ inputs.github-token }}
           npmrc=${{ inputs.npmrc }}


### PR DESCRIPTION
This pull request updates the `action.yml` file to change the variable name `github-pat` to `github-token`. This change ensures consistency and clarity in the codebase.