### PR TITLE
Add optional build context input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
   npmrc:
     description: "~/.npmrc file to use for private registries, will be provided as a secret named npmrc"
     required: false
+  context:
+    description: "Path to the build context"
+    required: false
+    default: "."
 
 runs:
   using: "composite"
@@ -64,7 +68,7 @@ runs:
       env:
         DOCKER_BUILDKIT: 1
       with:
-        context: .
+        context: ${{ inputs.context }}
         file: ./Dockerfile
         push: ${{ inputs.push }}
         tags: ${{ steps.set-image-name.outputs.image-name }}


### PR DESCRIPTION
This pull request adds an optional input parameter called "context" to the action.yml file. The "context" parameter allows users to specify the path to the build context. If the "context" parameter is not provided, the default value of "." (current directory) will be used. This enhancement provides more flexibility for users when building Docker images using the action.